### PR TITLE
fixes typescript build failure

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ const federationConfig = {
    },
    exposes: {
       "./AwesomeButton": "./src/components/AwesomeButton.tsx",
-      "./ButtonTypes": "@chakra-ui/button/src/button.tsx", // Getting Button Types from Chakra?
    },
    shared: {
       react: {


### PR DESCRIPTION
We don't need to export `ButtonTypes` as it is inherited by `AwesomeButton`